### PR TITLE
Fix: Replace cast with type conversion

### DIFF
--- a/src/net/ssehub/comani/core/ComAnI.java
+++ b/src/net/ssehub/comani/core/ComAnI.java
@@ -96,7 +96,7 @@ public class ComAnI {
         File pluginsDirectory = new File(pluginsDirectoryPath);
         InfrastructureUtilities.getInstance().setPluginsDirectory(pluginsDirectory);
         // Check for existence and validity of max. number of elements is done in setup already
-        int maxCommits = (int) coreProperties.get(Setup.PROPERTY_CORE_COMMIT_QUEUE_MAX_ELEMENTS);
+        int maxCommits = Integer.parseInt(coreProperties.get(Setup.PROPERTY_CORE_COMMIT_QUEUE_MAX_ELEMENTS).toString());
         CommitQueue commitQueue = new CommitQueue(maxCommits);
         ExtractionManager extractionManager = 
                 new ExtractionManager(coreProperties.getProperty(Setup.PROPERTY_CORE_OS),


### PR DESCRIPTION
Cast from String to int does not work. The method Integer.parseInt needs to be called instead.